### PR TITLE
HCK-8010: add comma commenting for last activated column statement

### DIFF
--- a/forward_engineering/ddlProvider/ddlProvider.js
+++ b/forward_engineering/ddlProvider/ddlProvider.js
@@ -1,6 +1,7 @@
 const defaultTypes = require('../configs/defaultTypes');
 const descriptors = require('../configs/descriptors');
 const templates = require('./templates');
+const { joinActivatedAndDeactivatedStatements } = require('../utils/joinActivatedAndDeactivatedStatements');
 
 module.exports = (baseProvider, options, app) => {
 	const _ = app.require('lodash');
@@ -205,12 +206,13 @@ module.exports = (baseProvider, options, app) => {
 				partitionOf && !keyConstraintsValue && !checkConstraintsValue && !foreignKeyConstraintsString;
 			const openParenthesis = isEmptyPartitionBody ? '' : '(';
 			const closeParenthesis = isEmptyPartitionBody ? '' : ')';
+			const columnStatements = joinActivatedAndDeactivatedStatements({ statements: columns, indent: '\n\t' });
 
 			const tableStatement = assignTemplates(template, {
 				temporary: getTableTemporaryValue(temporary, unlogged),
 				ifNotExist: ifNotExistStr,
 				name: tableName,
-				columnDefinitions: !partitionOf ? '\t' + _.join(columns, ',\n\t') : '',
+				columnDefinitions: !partitionOf ? '\t' + columnStatements : '',
 				keyConstraints: keyConstraintsValue,
 				checkConstraints: checkConstraintsValue,
 				foreignKeyConstraints: foreignKeyConstraintsString,

--- a/forward_engineering/utils/joinActivatedAndDeactivatedStatements.js
+++ b/forward_engineering/utils/joinActivatedAndDeactivatedStatements.js
@@ -1,0 +1,53 @@
+/**
+ * @param {{
+* index: number;
+* numberOfStatements: number;
+* lastIndexOfActivatedStatement: number;
+* delimiter: string;
+* }}
+* @return {string}
+* */
+const getDelimiter = ({ index, numberOfStatements, lastIndexOfActivatedStatement, delimiter }) => {
+ const isLastStatement = index === numberOfStatements - 1;
+ const isLastActivatedStatement = index === lastIndexOfActivatedStatement;
+
+ if (isLastStatement) {
+	 return '';
+ }
+
+ if (isLastActivatedStatement) {
+	 return ' --' + delimiter;
+ }
+
+ return delimiter;
+};
+
+/**
+* @param {{
+* statements?: string[];
+* delimiter?: string;
+* indent?: string;
+* }}
+* @return {string}
+* */
+const joinActivatedAndDeactivatedStatements = ({ statements = [], delimiter = ',', indent = '\n' }) => {
+ const lastIndexOfActivatedStatement = statements.findLastIndex(statement => !statement.startsWith('--'));
+ const numberOfStatements = statements.length;
+
+ return statements
+	 .map((statement, index) => {
+		 const currentDelimiter = getDelimiter({
+			 index,
+			 numberOfStatements,
+			 lastIndexOfActivatedStatement,
+			 delimiter,
+		 });
+
+		 return statement + currentDelimiter;
+	 })
+	 .join(indent);
+};
+
+module.exports = {
+ joinActivatedAndDeactivatedStatements,
+};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-8010" title="HCK-8010" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-8010</a>  [YugabyteDB]: DDL script is not valid when the last attribute is commented in Table
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
