### PR TITLE
HCK-8792: remove length default property from char and binary

### DIFF
--- a/types/binary.json
+++ b/types/binary.json
@@ -7,8 +7,7 @@
 	"hiddenOnEntity": "view",
 	"defaultValues": {
 		"primaryKey": false,
-		"mode": "bytea",
-		"length": 10
+		"mode": "bytea"
 	},
 	"descriptor": [
 		{

--- a/types/char.json
+++ b/types/char.json
@@ -13,7 +13,6 @@
 		"childRelationships": [],
 		"foreignCollection": "",
 		"foreignField": [],
-		"mode": "varchar",
-		"length": 10
+		"mode": "varchar"
 	}
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-8792" title="HCK-8792" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-8792</a>  Yugabyte - Change default length for char and varchar to "empty" (instead of 10)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
