### PR TITLE
HCK-9128: Handle indexes without name in YugabyteDB-YSQL

### DIFF
--- a/forward_engineering/ddlProvider/ddlProvider.js
+++ b/forward_engineering/ddlProvider/ddlProvider.js
@@ -277,7 +277,9 @@ module.exports = (baseProvider, options, app) => {
 		},
 
 		createIndex(tableName, index, dbData, isParentActivated = true) {
-			if (!index.columns.length) {
+			const isNameEmpty = !index.indxName && index.ifNotExist;
+
+			if (!index.columns.length || isNameEmpty) {
 				return '';
 			}
 

--- a/forward_engineering/ddlProvider/ddlProvider.js
+++ b/forward_engineering/ddlProvider/ddlProvider.js
@@ -277,6 +277,10 @@ module.exports = (baseProvider, options, app) => {
 		},
 
 		createIndex(tableName, index, dbData, isParentActivated = true) {
+			if (!index.columns.length) {
+				return '';
+			}
+
 			const name = wrapInQuotes(index.indxName);
 			const unique = index.unique && index.index_method === 'btree' ? ' UNIQUE' : '';
 			const concurrently = index.concurrently ? ' CONCURRENTLY' : '';

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -810,8 +810,11 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "Optional, if not specified an automatic name will be assigned. Index name are needed to drop indexes and appear in error messages when a constraint is violated.",
 						"propertyType": "text",
 						"dependency": {
-							"key": "ifNotExist",
-							"value": false
+							"type": "not",
+							"values": {
+								"key": "ifNotExist",
+								"value": true
+							}
 						}
 					},
 					{

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -808,7 +808,24 @@ making sure that you maintain a proper JSON format.
 						"propertyName": "Name",
 						"propertyKeyword": "indxName",
 						"propertyTooltip": "Optional, if not specified an automatic name will be assigned. Index name are needed to drop indexes and appear in error messages when a constraint is violated.",
-						"propertyType": "text"
+						"propertyType": "text",
+						"dependency": {
+							"key": "ifNotExist",
+							"value": false
+						}
+					},
+					{
+						"propertyName": "Name",
+						"propertyKeyword": "indxName",
+						"propertyTooltip": "",
+						"propertyType": "text",
+						"validation": {
+							"required": true
+						},
+						"dependency": {
+							"key": "ifNotExist",
+							"value": true
+						}
 					},
 					{
 						"propertyName": "Activated",

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -2,9 +2,9 @@
 * Copyright © 2016-2020 by IntegrIT S.A. dba Hackolade.  All rights reserved.
 *
 * The copyright to the computer software herein is the property of IntegrIT S.A.
-* The software may be used and/or copied only with the written permission of 
-* IntegrIT S.A. or in accordance with the terms and conditions stipulated in 
-* the agreement/contract under which the software has been supplied. 
+* The software may be used and/or copied only with the written permission of
+* IntegrIT S.A. or in accordance with the terms and conditions stipulated in
+* the agreement/contract under which the software has been supplied.
 
 In order to define custom properties for any object's properties pane, you may copy/paste from the following,
 making sure that you maintain a proper JSON format.
@@ -70,8 +70,8 @@ making sure that you maintain a proper JSON format.
 				]
 			},
 // “groupInput” can have the following states - 0 items, 1 item, and many items.
-// “blockInput” has only 2 states - 0 items or 1 item. 
-// This gives us an easy way to represent it as an object and not as an array internally which is beneficial for processing 
+// “blockInput” has only 2 states - 0 items or 1 item.
+// This gives us an easy way to represent it as an object and not as an array internally which is beneficial for processing
 // and forward-engineering in particular.
 			{
 				"propertyName": "Block",
@@ -99,7 +99,7 @@ making sure that you maintain a proper JSON format.
 				"propertyKeyword": "keyList",
 				"propertyType": "fieldList",
 				"template": "orderedList"
-			}, 
+			},
 			{
 				"propertyName": "List with attribute",
 				"propertyKeyword": "keyListOrder",
@@ -886,6 +886,10 @@ making sure that you maintain a proper JSON format.
 								"key": "index_method",
 								"value": "btree"
 							}
+						},
+						"validation": {
+							"required": true,
+							"minLength": 1
 						}
 					},
 					{
@@ -919,6 +923,10 @@ making sure that you maintain a proper JSON format.
 						"dependency": {
 							"key": "index_method",
 							"value": "btree"
+						},
+						"validation": {
+							"required": true,
+							"minLength": 1
 						}
 					},
 					{


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9128" title="HCK-9128" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9128</a>  Handle indexes without name in all SQL-like targets, depending whether name is mandatory or not
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Updated validation of required fields in "Create Index" script

- index name is required only if "IF NOT EXIST" is specified
- columns are required