### PR TITLE
HCK-9173: comment out inactive schema statement in script

### DIFF
--- a/forward_engineering/ddlProvider/ddlProvider.js
+++ b/forward_engineering/ddlProvider/ddlProvider.js
@@ -118,7 +118,7 @@ module.exports = (baseProvider, options, app) => {
 			});
 		},
 
-		createSchema({ schemaName, ifNotExist, comments, udfs, procedures }) {
+		createSchema({ schemaName, ifNotExist, comments, udfs, procedures, isActivated }) {
 			const comment = assignTemplates(templates.comment, {
 				object: 'SCHEMA',
 				objectName: wrapInQuotes(schemaName),
@@ -134,12 +134,13 @@ module.exports = (baseProvider, options, app) => {
 			const createFunctionStatement = getFunctionsScript(schemaName, udfs);
 			const createProceduresStatement = getProceduresScript(schemaName, procedures);
 
-			return _.chain([schemaStatement, createFunctionStatement, createProceduresStatement])
+			const statement = _.chain([schemaStatement, createFunctionStatement, createProceduresStatement])
 				.compact()
 				.map(_.trim)
 				.join('\n\n')
 				.trim()
 				.value();
+			return commentIfDeactivated(statement, { isActivated });
 		},
 
 		createTable(
@@ -704,6 +705,7 @@ module.exports = (baseProvider, options, app) => {
 				udfs: data?.udfs || [],
 				procedures: data?.procedures || [],
 				dbVersion,
+				isActivated: containerData.isActivated,
 			};
 		},
 

--- a/forward_engineering/ddlProvider/ddlProvider.js
+++ b/forward_engineering/ddlProvider/ddlProvider.js
@@ -118,7 +118,7 @@ module.exports = (baseProvider, options, app) => {
 			});
 		},
 
-		createSchema({ schemaName, ifNotExist, comments, udfs, procedures, isActivated }) {
+		createSchema({ schemaName, ifNotExist, comments, udfs, procedures, isActivated = true }) {
 			const comment = assignTemplates(templates.comment, {
 				object: 'SCHEMA',
 				objectName: wrapInQuotes(schemaName),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9173" title="HCK-9173" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-9173</a>  Statements are still incorrectly present in DDL/Script tab after 'isActivated' is disabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

You have no Jira task for this PR? Describe your changes here...

...

## Technical details

You feel the need to provide technical explanations? You can do it here...

...