### PR TITLE
HCK-10442: add adapter to properly derive hasMaxLength from Polyglot

### DIFF
--- a/polyglot/adapter.json
+++ b/polyglot/adapter.json
@@ -124,6 +124,24 @@
 				"to": {
 					"mode": "point"
 				}
+			},
+			{
+				"from": {
+					"type": "varchar",
+					"hasMaxLength": true
+				},
+				"to": {
+					"length": 10485760
+				}
+			},
+			{
+				"from": {
+					"type": "nvarchar",
+					"hasMaxLength": true
+				},
+				"to": {
+					"length": 10485760
+				}
 			}
 		]
 	}

--- a/polyglot/convertAdapter.json
+++ b/polyglot/convertAdapter.json
@@ -1,0 +1,49 @@
+/**
+ * {
+ * 		"add": {
+ * 			"entity": [<names of new property>],
+ * 			"container": [<names of new property>],
+ * 			"model": [<names of new property>],
+ * 			"view": [<names of new property>],
+ *			"field": {
+ *				"<type>": [<names of new property>]
+ *			}
+ * 		},
+ * 		"delete": {
+ * 			"entity": [<names of new property>],
+ * 			"container": [<names of new property>],
+ * 			"model": [<names of new property>],
+ * 			"view": [<names of new property>],
+ *			"field": {
+ *				"<type>": [<names of new property>]
+ *			}
+ * 		},
+ * 		"modify": {
+ *	 		"entity": [
+ *	 			{
+ *					"from": { <properties that identify record> },
+ *					"to": { <properties that need to be changed> }
+ *				}
+ *			],
+ *			"container": [],
+ *			"model": [],
+ *			"view": [],
+ *			"field": []
+ * 		},
+ * }
+ */
+ {
+	"modify": {
+		"field": [
+			{
+				"from": {
+					"mode": "varchar",
+					"length": 10485760
+				},
+				"to": {
+					"hasMaxLength": true
+				}
+			}
+		]
+	}
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10442" title="HCK-10442" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-10442</a>  Implement max length mapping for RDBMS-like database targets (cross-target conversion)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Added adapter to properly derive hasMaxLength from Polyglot