### PR TITLE
HCK-10537: updated adapter config to properly convert char hasMaxLength

### DIFF
--- a/polyglot/convertAdapter.json
+++ b/polyglot/convertAdapter.json
@@ -43,6 +43,15 @@
 				"to": {
 					"hasMaxLength": true
 				}
+			},
+			{
+				"from": {
+					"mode": "char",
+					"length": 10485760
+				},
+				"to": {
+					"hasMaxLength": true
+				}
 			}
 		]
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10537" title="HCK-10537" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-10537</a>  [YugabyteDB] char datatype with max length incorrect converted to Poly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Updated adapter config to properly convert char hasMaxLength