### PR TITLE
HCK-12999: enum should be created as UDT only

### DIFF
--- a/types/enum.json
+++ b/types/enum.json
@@ -3,6 +3,12 @@
 	"erdAbbreviation": "<enum>",
 	"dtdAbbreviation": "{enum}",
 	"parentType": "string",
-	"hiddenOnEntity": ["collection", "view"],
+	"hiddenOnEntity": ["view"],
+	"dependency": {
+		"level": "parent",
+		"key": "type",
+		"value": "definitions"
+	},
+	"disabledTooltip": "For these datatypes, the YugabyteDB YSQL specification requires that you create first a UDT, then reference it in your model.",
 	"defaultValues": {}
 }


### PR DESCRIPTION
## Technical details

For ENUM, the YugabyteDB YSQL specification requires that you first create a UDT, then reference it in your model. Similar to PosgtreSQL and Cockroach plugins.