### PR TITLE
HCK-13014: fix UDT-only types

### DIFF
--- a/types/composite.json
+++ b/types/composite.json
@@ -3,7 +3,13 @@
 	"erdAbbreviation": "<cmp>",
 	"dtdAbbreviation": "{...}",
 	"parentType": "document",
-	"hiddenOnEntity": ["collection", "view"],
+	"hiddenOnEntity": ["view"],
+	"dependency": {
+		"level": "parent",
+		"key": "type",
+		"value": "definitions"
+	},
+	"disabledTooltip": "For these datatypes, the YugabyteDB YSQL specification requires that you create first a UDT, then reference it in your model.",
 	"defaultValues": {
 		"properties": []
 	}

--- a/types/domain.json
+++ b/types/domain.json
@@ -3,6 +3,12 @@
 	"erdAbbreviation": "<dmn>",
 	"dtdAbbreviation": "{dmn}",
 	"parentType": "string",
-	"hiddenOnEntity": ["collection", "view"],
+	"hiddenOnEntity": ["view"],
+	"dependency": {
+		"level": "parent",
+		"key": "type",
+		"value": "definitions"
+	},
+	"disabledTooltip": "For these datatypes, the YugabyteDB YSQL specification requires that you create first a UDT, then reference it in your model.",
 	"defaultValues": {}
 }

--- a/types/range_udt.json
+++ b/types/range_udt.json
@@ -3,6 +3,12 @@
 	"erdAbbreviation": "<rng>",
 	"dtdAbbreviation": "{123}",
 	"parentType": "string",
-	"hiddenOnEntity": ["collection", "view"],
+	"hiddenOnEntity": ["view"],
+	"dependency": {
+		"level": "parent",
+		"key": "type",
+		"value": "definitions"
+	},
+	"disabledTooltip": "For these datatypes, the YugabyteDB YSQL specification requires that you create first a UDT, then reference it in your model.",
 	"defaultValues": {}
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-13014" title="HCK-13014" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-13014</a>  [Yugabyte] Composite, range and domain should also be UDT-only, as in PostgreSQL
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

The updated types can be created only as UDT and then referenced by columns.