### PR TITLE
HCK-13117: schema comment default

### DIFF
--- a/forward_engineering/config.json
+++ b/forward_engineering/config.json
@@ -291,7 +291,7 @@
 			"disabled": false,
 			"value": {
 				"inline": {
-					"default": true,
+					"default": false,
 					"disabled": true,
 					"disabledLabel": ""
 				},


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-13117" title="HCK-13117" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-13117</a>  [Yugabyte][Script generation options] Missing default setting value for Schema comments
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

* set only one default option to be enabled